### PR TITLE
RegistrationEventRouter now throws a human readable exception

### DIFF
--- a/src/proj/CommonDomain.Core/CommonDomain.Core.csproj
+++ b/src/proj/CommonDomain.Core/CommonDomain.Core.csproj
@@ -45,6 +45,7 @@
     <Compile Include="AggregateBase.cs" />
     <Compile Include="ConflictDetector.cs" />
     <Compile Include="ConventionEventRouter.cs" />
+    <Compile Include="HandlerForDomainEventNotFoundException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RegistrationEventRouter.cs" />
     <Compile Include="SagaBase.cs" />

--- a/src/proj/CommonDomain.Core/HandlerForDomainEventNotFoundException.cs
+++ b/src/proj/CommonDomain.Core/HandlerForDomainEventNotFoundException.cs
@@ -1,0 +1,12 @@
+namespace CommonDomain.Core
+{
+    using System;
+
+    public class HandlerForDomainEventNotFoundException : Exception
+    {
+        public HandlerForDomainEventNotFoundException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/proj/CommonDomain.Core/RegistrationEventRouter.cs
+++ b/src/proj/CommonDomain.Core/RegistrationEventRouter.cs
@@ -1,24 +1,32 @@
 namespace CommonDomain.Core
 {
-	using System;
-	using System.Collections.Generic;
+    using System;
+    using System.Collections.Generic;
 
-	public class RegistrationEventRouter<TEvent> : IRouteEvents<TEvent>
-	{
-		private readonly IDictionary<Type, Action<TEvent>> handlers = new Dictionary<Type, Action<TEvent>>();
+    public class RegistrationEventRouter<TEvent> : IRouteEvents<TEvent>
+    {
+        private readonly IDictionary<Type, Action<TEvent>> handlers = new Dictionary<Type, Action<TEvent>>();
+        private string _aggregateTypeName;
 
-		public virtual void Register<TEventMessage>(Action<TEventMessage> handler) where TEventMessage : TEvent
-		{
-			this.handlers[typeof(TEventMessage)] = @event => handler((TEventMessage)@event);
-		}
-		public virtual void Register(IAggregate aggregate)
-		{
-			// no-op
-		}
+        public virtual void Register<TEventMessage>(Action<TEventMessage> handler) where TEventMessage : TEvent
+        {
+            this.handlers[typeof(TEventMessage)] = @event => handler((TEventMessage)@event);
+        }
+        public virtual void Register(IAggregate aggregate)
+        {
+            _aggregateTypeName = aggregate.GetType().Name;
+        }
 
-		public virtual void Dispatch(object eventMessage)
-		{
-			this.handlers[eventMessage.GetType()]((TEvent)eventMessage);
-		}
-	}
+        public virtual void Dispatch(object eventMessage)
+        {
+            Action<TEvent> action;
+
+            if (!this.handlers.TryGetValue(eventMessage.GetType(), out action))
+            {
+                throw new HandlerForDomainEventNotFoundException(string.Format("Aggregate of type {0} raised and event of type {1}, but no handler was registered.", _aggregateTypeName, eventMessage.GetType().Name));
+            }
+
+            action((TEvent)eventMessage);
+        }
+    }
 }


### PR DESCRIPTION
Hi.

I added a minor improvement to the RegistrationEventRouter. When an event is raised but no handler is found, a better exception is thrown.
