### PR TITLE
Overload of GetById was preventing snapshots being used

### DIFF
--- a/src/proj/CommonDomain.Persistence.EventStore/EventStoreRepository.cs
+++ b/src/proj/CommonDomain.Persistence.EventStore/EventStoreRepository.cs
@@ -47,7 +47,7 @@ namespace CommonDomain.Persistence.EventStore
 
         public virtual TAggregate GetById<TAggregate>(Guid id) where TAggregate : class, IAggregate
         {
-            return GetById<TAggregate>(id, 0);
+            return GetById<TAggregate>(id, int.MaxValue);
         }
 
 	    public virtual TAggregate GetById<TAggregate>(Guid id, int versionToLoad) where TAggregate : class, IAggregate


### PR DESCRIPTION
The EventStore is so fast it's hard to notice but if you have enough events in a stream then it starts to have an effect and negates the benefit of any snapshots (only spotted it because I was working on the MongoDB commit stream loading).
