### PR TITLE
Passed stream headers to aggregate factory

### DIFF
--- a/src/proj/CommonDomain.Persistence.EventStore/EventStoreRepository.cs
+++ b/src/proj/CommonDomain.Persistence.EventStore/EventStoreRepository.cs
@@ -69,7 +69,7 @@ namespace CommonDomain.Persistence.EventStore
 		private IAggregate GetAggregate<TAggregate>(Snapshot snapshot, IEventStream stream)
 		{
 			var memento = snapshot == null ? null : snapshot.Payload as IMemento;
-			return this.factory.Build(typeof(TAggregate), stream.StreamId, memento);
+			return this.factory.Build(typeof(TAggregate), stream.StreamId, memento, stream.CommittedHeaders);
 		}
 		private Snapshot GetSnapshot(Guid id, int version)
 		{

--- a/src/proj/CommonDomain.Persistence/IConstructAggregates.cs
+++ b/src/proj/CommonDomain.Persistence/IConstructAggregates.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
+
 namespace CommonDomain.Persistence
 {
 	using System;
 
 	public interface IConstructAggregates
 	{
-		IAggregate Build(Type type, Guid id, IMemento snapshot);
+		IAggregate Build(Type type, Guid id, IMemento snapshot, IDictionary<string, object> headers);
 	}
 }


### PR DESCRIPTION
I propose to change interface IConstructAggregates to pass to factory stream headers.

That's convenient - load aggregate by interface (for example IOwner), but stored events were generated by interface implementation (and stream header AggregateType points to concrete implementation of interface IOwner).

If my explanation is unclear, I'll provide more detailed example.

Regards,
Dmitry 
