### PR TITLE
Fixed ilmerge using the wrong reference assemblies if you have .NET 4.5 installed.

### DIFF
--- a/build/Modules/ILMerge.psm1
+++ b/build/Modules/ILMerge.psm1
@@ -1,13 +1,14 @@
 $script:ilMergeModule = @{}
 $script:ilMergeModule.ilMergePath = $null
 
+<# see this article: http://www.mattwrock.com/post/2012/02/29/What-you-should-know-about-running-ILMerge-on-Net-45-Beta-assemblies-targeting-Net-40.aspx #>
 function Merge-Assemblies {
 	Param(
 		$files,
 		$outputFile,
 		$exclude,
 		$keyfile,
-		$targetPlatform="v4,C:/WINDOWS/Microsoft.NET/Framework/v4.0.30319"
+		$targetPlatform="v4,C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0"
 	)
 
 	$exclude | out-file ".\exclude.txt"


### PR DESCRIPTION
Got this code from the same change in joliver/EventStore. 
